### PR TITLE
Adds color-named rule

### DIFF
--- a/rules/core/color-named/README.md
+++ b/rules/core/color-named/README.md
@@ -1,0 +1,27 @@
+#### 📍 color-named
+
+Does not allow colour names to be used within CSS, only hex & rgb(a) codes are accepted.
+
+##### 🧟 Example of incorrect code for this rule:
+
+a {
+    color: black;
+}
+
+a {
+    color: white;
+}
+
+##### 🦄 Example of correct code for this rule:
+
+a {
+    color: #ffffff;
+}
+
+a {
+    color: @black;
+}
+
+a {
+    color: rgba(0, 0, 0);
+}

--- a/rules/core/color-named/README.md
+++ b/rules/core/color-named/README.md
@@ -4,6 +4,7 @@ Does not allow colour names to be used within CSS, only hex & rgb(a) codes are a
 
 ##### 🧟 Example of incorrect code for this rule:
 
+```css
 a {
     color: black;
 }
@@ -11,9 +12,11 @@ a {
 a {
     color: white;
 }
+```
 
 ##### 🦄 Example of correct code for this rule:
 
+```css
 a {
     color: #ffffff;
 }
@@ -25,3 +28,4 @@ a {
 a {
     color: rgba(0, 0, 0);
 }
+```

--- a/rules/core/color-named/rule.js
+++ b/rules/core/color-named/rule.js
@@ -1,0 +1,7 @@
+const _THROW = require('../../../modules/throwables');
+
+module.exports = {
+    rules: {
+        'color-named': ['never', _THROW.ERROR],
+    }
+}


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<color-named>` : `severity: (ERROR)`

## Reason for addition/amendment
>Prevents the use of colour names being used in style code. Instead enforces rule of using hex, variables or rgb(a).
>See more details in README.md

@netsells/frontend - Please review 